### PR TITLE
feat: setup backlog page

### DIFF
--- a/app/components/Backlog/AddToBacklogModal.vue
+++ b/app/components/Backlog/AddToBacklogModal.vue
@@ -1,0 +1,273 @@
+<template>
+  <UModal
+    title="Add to Backlog"
+    description="Search for albums to add to your backlog"
+    :content="{ onOpenAutoFocus: (e) => e.preventDefault() }"
+  >
+    <template #body>
+      <div class="flex flex-col gap-4">
+        <!-- Search input -->
+        <div class="search-section">
+          <input
+            v-model="searchInput"
+            type="text"
+            placeholder="Search for an album..."
+            class="search-input"
+            @input="handleSearchInput"
+          />
+        </div>
+
+        <!-- Loading state -->
+        <div v-if="loading" class="search-results">
+          <div v-for="i in 3" :key="i" class="album-card skeleton"></div>
+        </div>
+
+        <!-- Search results with multi-select -->
+        <div v-else-if="searchResults.length > 0" class="search-results">
+          <div
+            v-for="album in searchResults"
+            :key="album.id"
+            class="album-card"
+            :class="{ selected: isSelected(album) }"
+            @click="toggleSelection(album)"
+          >
+            <div class="checkbox-wrapper">
+              <UIcon
+                v-if="isSelected(album)"
+                name="i-heroicons-check-circle-solid"
+                class="text-xl"
+              />
+              <UIcon
+                v-else
+                name="i-heroicons-plus-circle"
+                class="text-xl text-gray-500"
+              />
+            </div>
+            <img
+              v-if="album.images?.[0]?.url"
+              :src="album.images[0].url"
+              :alt="album.name"
+              class="album-image"
+            />
+            <div class="album-info">
+              <div class="album-name">{{ album.name }}</div>
+              <div class="artist-names">{{ getArtistNames(album) }}</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Selected albums summary -->
+        <div v-if="selectedAlbums.length > 0" class="selected-summary">
+          <div class="selected-count">
+            {{ selectedAlbums.length }} album{{
+              selectedAlbums.length === 1 ? '' : 's'
+            }}
+            selected
+          </div>
+          <UButton
+            color="neutral"
+            variant="ghost"
+            size="sm"
+            @click="clearSelection"
+          >
+            Clear
+          </UButton>
+        </div>
+
+        <!-- Add button -->
+        <UButton
+          v-if="selectedAlbums.length > 0"
+          block
+          color="primary"
+          size="lg"
+          :loading="saving"
+          @click="handleAdd"
+        >
+          Add {{ selectedAlbums.length }} Album{{
+            selectedAlbums.length === 1 ? '' : 's'
+          }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>
+
+<script lang="ts" setup>
+import type { SearchResult } from '~/composables/api/useSpotifyAlbumSearch';
+
+const emit = defineEmits<{
+  close: [];
+  added: [];
+}>();
+
+const { searchResults, loading, search } = useSpotifyAlbumSearch();
+const {
+  selectedAlbums,
+  saving,
+  isSelected,
+  toggleSelection,
+  clearSelection,
+  addToBacklog,
+} = useAddToBacklog({
+  onSuccess: () => {
+    emit('added');
+    emit('close');
+  },
+});
+
+const searchInput = ref('');
+
+const handleSearchInput = (e: Event) => {
+  const target = e.target as HTMLInputElement;
+  search(target.value);
+};
+
+const getArtistNames = (album: SearchResult) =>
+  album.artists.map((a) => a.name).join(', ');
+
+const handleAdd = async () => {
+  await addToBacklog();
+};
+</script>
+
+<style scoped>
+.search-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.search-input {
+  width: 100%;
+  padding: 12px 16px;
+  background-color: #282828;
+  border: 2px solid #404040;
+  border-radius: 8px;
+  color: #ffffff;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 16px;
+  transition: border-color 0.2s ease;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #1db954;
+}
+
+.search-input::placeholder {
+  color: #b3b3b3;
+}
+
+.search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 300px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.album-card {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  background-color: #282828;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  align-items: center;
+}
+
+.album-card:hover {
+  background-color: #333333;
+}
+
+.album-card.selected {
+  background-color: #1db954;
+}
+
+.album-card.skeleton {
+  height: 80px;
+  background: linear-gradient(
+    90deg,
+    #2a2a2a 25%,
+    #3a3a3a 37%,
+    #2a2a2a 63%
+  );
+  background-size: 400% 100%;
+  animation: skeleton-shimmer 2.5s ease infinite;
+}
+
+.checkbox-wrapper {
+  flex-shrink: 0;
+}
+
+.album-image {
+  width: 56px;
+  height: 56px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.album-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.album-name {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.album-card.selected .album-name {
+  color: #000000;
+}
+
+.artist-names {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  color: #b3b3b3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.album-card.selected .artist-names {
+  color: #121212;
+}
+
+.selected-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  background-color: #1a1a1a;
+  border-radius: 8px;
+}
+
+.selected-count {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1db954;
+}
+
+@keyframes skeleton-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: -100% 0;
+  }
+}
+</style>

--- a/app/components/Backlog/BacklogItem.vue
+++ b/app/components/Backlog/BacklogItem.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="backlog-item">
+    <img
+      v-if="album.imageUrl"
+      :src="album.imageUrl"
+      :alt="album.name"
+      class="album-image"
+    />
+    <div v-else class="album-image placeholder">
+      <UIcon name="i-heroicons-musical-note" class="text-3xl text-gray-500" />
+    </div>
+    <div class="album-info">
+      <div class="album-name">{{ album.name }}</div>
+      <div class="artist-names">{{ artistNames }}</div>
+    </div>
+    <UButton
+      color="neutral"
+      variant="ghost"
+      size="sm"
+      icon="i-heroicons-trash"
+      :loading="deleting"
+      @click="handleDelete"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { BacklogAlbum } from '#shared/schema';
+
+const props = defineProps<{
+  album: BacklogAlbum;
+}>();
+
+const emit = defineEmits<{
+  deleted: [];
+}>();
+
+const artistNames = computed(() =>
+  props.album.artists.map((a) => a.name).join(', '),
+);
+
+const { deleting, deleteItem } = useDeleteBacklogItem({
+  onSuccess: () => emit('deleted'),
+});
+
+const handleDelete = async () => {
+  await deleteItem(props.album.id);
+};
+</script>
+
+<style scoped>
+.backlog-item {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+  background-color: #282828;
+  border-radius: 8px;
+  align-items: center;
+  transition: background-color 0.2s ease;
+}
+
+.backlog-item:hover {
+  background-color: #333333;
+}
+
+.album-image {
+  width: 64px;
+  height: 64px;
+  border-radius: 4px;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.album-image.placeholder {
+  background-color: #404040;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.album-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.album-name {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  color: #ffffff;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.artist-names {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #b3b3b3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -1,11 +1,29 @@
 <script setup lang="ts">
-import type { DropdownMenuItem } from '@nuxt/ui';
+import type { DropdownMenuItem, NavigationMenuItem } from '@nuxt/ui';
 import { signOut } from '~/lib/auth-client';
 import { Route } from '~/pages/routes';
 import { Icons } from './common/icons';
 
 const { loggedIn, user, loading } = useAuth();
 const router = useRouter();
+const route = useRoute();
+
+const navItems = computed<NavigationMenuItem[][]>(() => [
+  [
+    {
+      label: 'Dashboard',
+      icon: 'i-lucide-calendar',
+      to: Route.DASHBOARD,
+      active: route.path === Route.DASHBOARD,
+    },
+    {
+      label: 'Backlog',
+      icon: 'i-lucide-list-music',
+      to: Route.BACKLOG,
+      active: route.path === Route.BACKLOG,
+    },
+  ],
+]);
 
 const menuItems = computed<DropdownMenuItem[]>(() => [
   [
@@ -51,6 +69,9 @@ const menuItems = computed<DropdownMenuItem[]>(() => [
 
 <template>
   <UHeader title="DailySpin">
+    <template v-if="loggedIn" #body>
+      <UNavigationMenu :items="navItems" highlight />
+    </template>
 
     <template #toggle>
       <USkeleton v-if="loading" class="h-8 w-8 rounded-full mr-1.5"/>

--- a/app/composables/api/useAddToBacklog.ts
+++ b/app/composables/api/useAddToBacklog.ts
@@ -1,0 +1,77 @@
+import { ref } from 'vue';
+import type { AddBacklogItemsResponse } from '#shared/schema';
+import type { SearchResult } from './useSpotifyAlbumSearch';
+
+type UseAddToBacklogProps = {
+  onSuccess?: (response: AddBacklogItemsResponse) => void;
+};
+
+export const useAddToBacklog = ({
+  onSuccess = () => {},
+}: UseAddToBacklogProps = {}) => {
+  const selectedAlbums = ref<SearchResult[]>([]);
+  const saving = ref(false);
+  const error = ref<string | null>(null);
+
+  const isSelected = (album: SearchResult) =>
+    selectedAlbums.value.some((a) => a.id === album.id);
+
+  const toggleSelection = (album: SearchResult) => {
+    if (isSelected(album)) {
+      selectedAlbums.value = selectedAlbums.value.filter(
+        (a) => a.id !== album.id,
+      );
+    } else {
+      selectedAlbums.value = [...selectedAlbums.value, album];
+    }
+  };
+
+  const clearSelection = () => {
+    selectedAlbums.value = [];
+  };
+
+  const addToBacklog = async () => {
+    if (selectedAlbums.value.length === 0) return;
+
+    saving.value = true;
+    error.value = null;
+
+    try {
+      const body = selectedAlbums.value.map((album) => ({
+        spotifyId: album.id,
+        name: album.name,
+        imageUrl: album.images[0]?.url,
+        releaseDate: album.release_date,
+        totalTracks: album.total_tracks,
+        artists: album.artists.map((artist) => ({
+          spotifyId: artist.id,
+          name: artist.name,
+        })),
+      }));
+
+      const response = await $fetch<AddBacklogItemsResponse>('/api/backlog', {
+        method: 'POST',
+        body,
+      });
+
+      clearSelection();
+      onSuccess(response);
+      return response;
+    } catch (err) {
+      error.value = err instanceof Error ? err.message : 'Failed to add albums';
+      throw err;
+    } finally {
+      saving.value = false;
+    }
+  };
+
+  return {
+    selectedAlbums,
+    saving,
+    error,
+    isSelected,
+    toggleSelection,
+    clearSelection,
+    addToBacklog,
+  };
+};

--- a/app/composables/api/useBacklog.ts
+++ b/app/composables/api/useBacklog.ts
@@ -1,0 +1,7 @@
+import type { GetBacklogResponse } from '#shared/schema';
+
+export const useBacklog = () => {
+  return useFetch<GetBacklogResponse>('/api/backlog', {
+    key: 'backlog',
+  });
+};

--- a/app/composables/api/useDeleteBacklogItem.ts
+++ b/app/composables/api/useDeleteBacklogItem.ts
@@ -1,0 +1,37 @@
+import { ref } from 'vue';
+
+type UseDeleteBacklogItemProps = {
+  onSuccess?: () => void;
+};
+
+export const useDeleteBacklogItem = ({
+  onSuccess = () => {},
+}: UseDeleteBacklogItemProps = {}) => {
+  const deleting = ref(false);
+  const error = ref<string | null>(null);
+
+  const deleteItem = async (id: string) => {
+    deleting.value = true;
+    error.value = null;
+
+    try {
+      await $fetch(`/api/backlog/${id}`, {
+        method: 'DELETE',
+      });
+
+      onSuccess();
+    } catch (err) {
+      error.value =
+        err instanceof Error ? err.message : 'Failed to remove album';
+      throw err;
+    } finally {
+      deleting.value = false;
+    }
+  };
+
+  return {
+    deleting,
+    error,
+    deleteItem,
+  };
+};

--- a/app/pages/backlog.vue
+++ b/app/pages/backlog.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+const { data, pending, error, refresh } = useBacklog();
+
+const isAddModalOpen = ref(false);
+
+const openAddModal = () => {
+  isAddModalOpen.value = true;
+};
+
+const closeAddModal = () => {
+  isAddModalOpen.value = false;
+};
+
+const handleAdded = () => {
+  refresh();
+};
+
+const handleDeleted = () => {
+  refresh();
+};
+
+const albums = computed(() => data.value?.albums ?? []);
+</script>
+
+<template>
+  <div class="backlog-container">
+    <main class="main-content">
+      <div class="page-header">
+        <h1 class="page-title">Backlog</h1>
+        <UButton
+          color="primary"
+          icon="i-heroicons-plus"
+          @click="openAddModal"
+        >
+          Add Albums
+        </UButton>
+      </div>
+
+      <!-- Loading state -->
+      <div v-if="pending" class="loading">Loading...</div>
+
+      <!-- Error state -->
+      <div v-else-if="error" class="error">Error: {{ error }}</div>
+
+      <!-- Empty state -->
+      <div v-else-if="albums.length === 0" class="empty-state">
+        <UIcon
+          name="i-heroicons-queue-list"
+          class="text-6xl text-gray-600 mb-4"
+        />
+        <p class="empty-title">Your backlog is empty</p>
+        <p class="empty-description">
+          Add albums you want to listen to later
+        </p>
+        <UButton
+          color="primary"
+          icon="i-heroicons-plus"
+          class="mt-4"
+          @click="openAddModal"
+        >
+          Add Your First Album
+        </UButton>
+      </div>
+
+      <!-- Backlog list -->
+      <div v-else class="backlog-list">
+        <BacklogItem
+          v-for="album in albums"
+          :key="album.id"
+          :album="album"
+          @deleted="handleDeleted"
+        />
+      </div>
+    </main>
+
+    <!-- Add to backlog modal -->
+    <AddToBacklogModal
+      v-if="isAddModalOpen"
+      @close="closeAddModal"
+      @added="handleAdded"
+    />
+  </div>
+</template>
+
+<style scoped>
+.backlog-container {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #121212;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.main-content {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 24px;
+  width: 100%;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.page-title {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 900;
+  letter-spacing: -0.02em;
+  color: #ffffff;
+}
+
+.loading,
+.error {
+  text-align: center;
+  padding: 48px 24px;
+  font-size: 16px;
+  font-weight: 500;
+  color: #b3b3b3;
+}
+
+.error {
+  color: #f15e6c;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 24px;
+  text-align: center;
+  flex: 1;
+}
+
+.empty-title {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 20px;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+}
+
+.empty-description {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: #b3b3b3;
+  margin: 8px 0 0;
+}
+
+.backlog-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+@media (max-width: 768px) {
+  .main-content {
+    padding: 16px;
+  }
+
+  .page-title {
+    font-size: 24px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    gap: 16px;
+    align-items: stretch;
+  }
+}
+</style>

--- a/app/pages/routes.ts
+++ b/app/pages/routes.ts
@@ -2,6 +2,7 @@ import type { RouteLocationNormalizedGeneric } from 'vue-router';
 
 export enum Route {
   DASHBOARD = '/dashboard',
+  BACKLOG = '/backlog',
   LANDING_PAGE = '/',
 }
 


### PR DESCRIPTION
Add composables for fetching, adding, and deleting backlog items:
- useBacklog: fetch backlog items
- useAddToBacklog: multi-select album addition
- useDeleteBacklogItem: remove items from backlog

Add backlog page with list view and empty state, plus modal for adding albums with multi-select support. Update header with navigation menu for Dashboard and Backlog pages.