### PR TITLE
fix: correctly detect order when album restarts after completion (#78)


### DIFF
--- a/server/utils/tracks.utils.test.ts
+++ b/server/utils/tracks.utils.test.ts
@@ -147,6 +147,127 @@ describe('tracks.utils', () => {
 
       expect(areTracksInOrder(tracks)).toBe(true);
     });
+
+    it('should return true when album restarts from beginning after completing', () => {
+      const tracks: PlayHistoryWithIndex[] = [
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:00:00Z',
+          context: context(),
+          playIndex: 1,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 2 }),
+          played_at: '2024-01-01T10:05:00Z',
+          context: context(),
+          playIndex: 2,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 3 }),
+          played_at: '2024-01-01T10:10:00Z',
+          context: context(),
+          playIndex: 3,
+        },
+        // Album restarts
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:15:00Z',
+          context: context(),
+          playIndex: 4,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 2 }),
+          played_at: '2024-01-01T10:20:00Z',
+          context: context(),
+          playIndex: 5,
+        },
+      ];
+
+      expect(areTracksInOrder(tracks)).toBe(true);
+    });
+
+    it('should return true when multi-disc album restarts from beginning', () => {
+      const tracks: PlayHistoryWithIndex[] = [
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:00:00Z',
+          context: context(),
+          playIndex: 1,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 2 }),
+          played_at: '2024-01-01T10:05:00Z',
+          context: context(),
+          playIndex: 2,
+        },
+        {
+          track: track({ disc_number: 2, track_number: 1 }),
+          played_at: '2024-01-01T10:10:00Z',
+          context: context(),
+          playIndex: 3,
+        },
+        {
+          track: track({ disc_number: 2, track_number: 2 }),
+          played_at: '2024-01-01T10:15:00Z',
+          context: context(),
+          playIndex: 4,
+        },
+        // Album restarts from disc 1
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:20:00Z',
+          context: context(),
+          playIndex: 5,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 2 }),
+          played_at: '2024-01-01T10:25:00Z',
+          context: context(),
+          playIndex: 6,
+        },
+      ];
+
+      expect(areTracksInOrder(tracks)).toBe(true);
+    });
+
+    it('should return false when album restarts but then plays out of order', () => {
+      const tracks: PlayHistoryWithIndex[] = [
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:00:00Z',
+          context: context(),
+          playIndex: 1,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 2 }),
+          played_at: '2024-01-01T10:05:00Z',
+          context: context(),
+          playIndex: 2,
+        },
+        {
+          track: track({ disc_number: 1, track_number: 3 }),
+          played_at: '2024-01-01T10:10:00Z',
+          context: context(),
+          playIndex: 3,
+        },
+        // Album restarts
+        {
+          track: track({ disc_number: 1, track_number: 1 }),
+          played_at: '2024-01-01T10:15:00Z',
+          context: context(),
+          playIndex: 4,
+        },
+        // Skipped track 2, jumped to track 4
+        {
+          track: track({ disc_number: 1, track_number: 4 }),
+          played_at: '2024-01-01T10:20:00Z',
+          context: context(),
+          playIndex: 5,
+        },
+      ];
+
+      expect(areTracksInOrder(tracks)).toBe(false);
+    });
   });
 
   describe('groupTracksByAlbum', () => {

--- a/server/utils/tracks.utils.ts
+++ b/server/utils/tracks.utils.ts
@@ -15,6 +15,18 @@ export const areTracksInOrder = (tracks: PlayHistoryWithIndex[]): boolean => {
       continue;
     }
 
+    // Check if album is restarting from the beginning (disc 1, track 1 after we've played some tracks)
+    if (
+      currentDiscNumber === 1 &&
+      currentTrackNumber === 1 &&
+      previousTrackNumber > 0
+    ) {
+      // Album restarted, reset tracking
+      previousTrackNumber = 1;
+      previousDiscNumber = 1;
+      continue;
+    }
+
     if (currentDiscNumber < previousDiscNumber) {
       // Went backwards to a previous disc - not in order
       return false;


### PR DESCRIPTION

When a user continues listening to an album after it finishes (causing
it to restart from track 1), the order detection now correctly identifies
this as "ordered" instead of "shuffled". The fix detects when disc 1,
track 1 appears after we've already played some tracks and treats it as
an album restart, resetting the order tracking.


Closes #78