### PR TITLE
fix: include noSkip field in manual listen POST body

### DIFF
--- a/app/composables/api/listens/useLogAlbum.test.ts
+++ b/app/composables/api/listens/useLogAlbum.test.ts
@@ -120,6 +120,7 @@ describe('useLogAlbum', () => {
             listenOrder: 'ordered',
             listenMethod: 'spotify',
             listenTime: 'morning',
+            noSkip: false,
           },
         },
       });

--- a/app/composables/api/listens/useLogAlbum.ts
+++ b/app/composables/api/listens/useLogAlbum.ts
@@ -16,6 +16,7 @@ export const useLogAlbum = ({
   const listenTime = ref<ListenTime>(
     getTrackListenTime(new Date().toISOString()),
   );
+  const noSkip = ref(false);
 
   const saving = ref(false);
 
@@ -24,6 +25,7 @@ export const useLogAlbum = ({
     listenOrder.value = 'ordered';
     listenMethod.value = 'spotify';
     listenTime.value = getTrackListenTime(new Date().toISOString());
+    noSkip.value = false;
   };
 
   const logAlbumListen = async () => {
@@ -50,6 +52,7 @@ export const useLogAlbum = ({
             listenOrder: listenOrder.value,
             listenMethod: listenMethod.value,
             listenTime: listenTime.value,
+            noSkip: noSkip.value,
           },
         },
       });
@@ -68,6 +71,7 @@ export const useLogAlbum = ({
     listenOrder,
     listenMethod,
     listenTime,
+    noSkip,
     saving,
     logAlbumListen,
   };


### PR DESCRIPTION
The ListenMetadataSchema requires noSkip as a required boolean, but the
useLogAlbum composable was not sending it, causing a 400 validation error
when manually logging album listens.

https://claude.ai/code/session_018XAJB3KFfmRFrKPNPkGpXJ